### PR TITLE
fix for emacs 30.1, compatible with 29.4

### DIFF
--- a/rexx-mode.el
+++ b/rexx-mode.el
@@ -485,7 +485,7 @@ table to convert all REXX keywords into upper case."
     )
   (require 'font-lock)
 
-  (run-hooks 'rexx-mode-hook))
+  (run-mode-hooks 'rexx-mode-hook))
 
 
 (defun rexx-indent-command (&optional whole-exp)


### PR DESCRIPTION
New mac, homebrew installed emacs 30.1, rexx-mode.el (and netrexx-mode.el) stopped syntax colouring with font-lock.
After correspondence on emacs-dev it turned out that minor modes bla. were incurably improved. hook must now be mode-hook; fixed in this commit.